### PR TITLE
Prevent warning with psycopg2 binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ ENV ADMIN_PWD superset
 
 # by default only includes PostgreSQL because I'm selfish
 ENV DB_PACKAGES libpq-dev
-ENV DB_PIP_PACKAGES psycopg2 sqlalchemy-redshift
+ENV DB_PIP_PACKAGES psycopg2-binary sqlalchemy-redshift
 
 RUN apt-get update \
 && apt-get install -y \


### PR DESCRIPTION
Fix for following warning:

```
/usr/local/lib/python3.6/site-packages/psycopg2/__init__.py:144: UserWarning: The psycopg2 wheel package will be renamed from release 2.8; in order to keep installing from binary please use "pip install psycopg2-binary" instead. For details see: <http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.
  """)
```